### PR TITLE
Excludes hidden paths from retype config search.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,7 +104,7 @@ else
     echo -n "/retype.json, "
   else
     echo -n "locate, "
-    locate_cf="$(find ./ -mindepth 2 -maxdepth 3 -iname retype.yml -o -iname retype.yaml -o -iname retype.json | cut -b 2-)"
+    locate_cf="$(find ./ -mindepth 2 -maxdepth 3 -not -path ".*" -iname retype.yml -o -iname retype.yaml -o -iname retype.json | cut -b 2-)"
 
     cf_count="$(echo "${locate_cf}" | wc -l)"
 


### PR DESCRIPTION
Hidden paths (starting with a dot) will no longer be used while
searching for Retype configuration files.

This will avoid, for instance, selecting workflow files that matches the
config file name when no config file is on root of the repo.

Related GitHub issue: retypeapp/retype#257.