### PR TITLE
Properly checks whether no config file is found in repo.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -108,7 +108,7 @@ else
 
     cf_count="$(echo "${locate_cf}" | wc -l)"
 
-    if [ ${cf_count} -eq 0 ]; then
+    if [ -z ${cf_count} ]; then
       missing_retypecf=true
       echo -n "initialize default configuration"
       result="$(retype init --verbose 2>&1)" || \


### PR DESCRIPTION
Now checks correctly whether the output of the find command is empty to
assume no config could be found and initialize with default one.

The script was returning an empty result which counted as "one line
result", then an empty path was being assigned as config file in case no
valid one was found, thus passing an empty parameter to retype startup
leading to failure.

Related GitHub issue: retypeapp/retype#257.