### PR TITLE
Fixes issues with retype.yml config file locate algorithm.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -104,11 +104,9 @@ else
     echo -n "/retype.json, "
   else
     echo -n "locate, "
-    locate_cf="$(find ./ -mindepth 2 -maxdepth 3 -iname retype.yml -o -iname retype.yaml -o -iname retype.json | cut -b 2-)"
+    locate_cf="$(find ./ -mindepth 2 -maxdepth 3 -not -path "*/.*" -a \( -iname retype.yml -o -iname retype.yaml -o -iname retype.json \) | cut -b 2-)"
 
-    cf_count="$(echo "${locate_cf}" | wc -l)"
-
-    if [ ${cf_count} -eq 0 ]; then
+    if [ -z "${locate_cf}" ]; then
       missing_retypecf=true
       echo -n "initialize default configuration"
       result="$(retype init --verbose 2>&1)" || \
@@ -119,14 +117,19 @@ else
 ${result}
 ::endgroup::"
       echo -n "Setting up build arguments: resume, "
-    elif [ ${cf_count} -ne 1 ]; then
-      fail_nl "More than one possible Retype configuration files found. Please remove extra files or specify the desired path with the 'config' argument (https://github.com/retypeapp/action-build#specify-path-to-the-retypeyml-file). See output for the list of paths found.
+
+    else
+      cf_count="$(echo "${locate_cf}" | wc -l)"
+
+      if [ ${cf_count} -ne 1 ]; then
+       fail_nl "More than one possible Retype configuration files found. Please remove extra files or specify the desired path with the 'config' argument (https://github.com/retypeapp/action-build#specify-path-to-the-retypeyml-file). See output for the list of paths found.
 
 Configuration files located:
 ${locate_cf}"
-    else
-      echo -n "${locate_cf}, "
-      cmdargs+=("${locate_cf:1}")
+      else
+        echo -n "${locate_cf}, "
+        cmdargs+=("${locate_cf:1}")
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
- Hidden paths (starting with a dot) will no longer be used while
  searching for Retype configuration files.

This will avoid, for instance, selecting workflow files that matches the
config file name when no config file is on root of the repo.

- Properly checks whether no file is found in case there's no file in
  root and repository search was performed.

An empty file list result would also count as "1 line" result, thus
checking for an empty result is necessary, instead of "zero lines" in
the output variable.

Related GitHub issue: retypeapp/retype#257.

A previous attempt to fix the issue had other issues which were solved by this pull request.